### PR TITLE
adding additional package to dependencies that is frequently missing

### DIFF
--- a/src/installation/install-linux-opensuse.md
+++ b/src/installation/install-linux-opensuse.md
@@ -11,7 +11,7 @@ sudo zypper dup
 ## 2 Install necessary dependencies:
 
 ```bash    
-sudo zypper install nodejs gcc make git`
+sudo zypper install nodejs gcc make git ca-certificates{,-cacert,-mozilla}
 ```
 
 ## 3 Verify correct Nodejs version (needs to be 14+)


### PR DESCRIPTION
Proper cacerts are missing in many out of the box OpenSUSE installs. Added the necessary packages to the dependency install step.